### PR TITLE
Add scoped element registration for plugins

### DIFF
--- a/FilterNetexApp_README.md
+++ b/FilterNetexApp_README.md
@@ -347,6 +347,24 @@ println("Total ServiceJourneys: ${counter.getCollectedData()}")
 Override whichever variant matches your processing mode. The `String` overload
 defaults to delegating to the `File` overload.
 
+**Scoped element registration:**
+
+Use `"Ancestor/Element"` syntax in `getSupportedElementTypes()` to match elements
+only inside a specific ancestor. This avoids false matches on generic element names
+like `Date` or `Name`:
+
+```kotlin
+override fun getSupportedElementTypes() = setOf(
+    "DayTypeAssignment",               // match DayTypeAssignment anywhere
+    "DayTypeAssignment/Date",           // match Date only inside DayTypeAssignment
+    "DayTypeAssignment/FromDate",       // match FromDate only inside DayTypeAssignment
+    "ScheduledStopPoint/Longitude",     // match Longitude only inside ScheduledStopPoint
+)
+```
+
+Note: SAX parsers may split character data across multiple `characters()` calls,
+so always accumulate with `StringBuilder` rather than overwriting.
+
 ### XMLElementHandler
 
 Custom element handlers let you transform specific XML elements during Phase 3

--- a/lib/src/main/java/org/entur/netex/tools/lib/plugin/PluginRegistry.kt
+++ b/lib/src/main/java/org/entur/netex/tools/lib/plugin/PluginRegistry.kt
@@ -23,7 +23,7 @@ class PluginRegistry {
         plugin.getSupportedElementTypes().forEach { elementType ->
             if ("/" in elementType) {
                 val parts = elementType.split("/")
-                require(parts.size == 2) {
+                require(parts.size == 2 && parts.all { it.isNotBlank() }) {
                     "Scoped element type must be 'Ancestor/Element', got: $elementType"
                 }
                 val (ancestor, leaf) = parts

--- a/lib/src/main/java/org/entur/netex/tools/lib/plugin/PluginRegistry.kt
+++ b/lib/src/main/java/org/entur/netex/tools/lib/plugin/PluginRegistry.kt
@@ -3,11 +3,15 @@ package org.entur.netex.tools.lib.plugin
 import org.entur.netex.tools.lib.extensions.putOrAddToList
 
 /**
- * Registry for managing NetEx plugins
+ * Registry for managing NetEx plugins.
+ *
+ * Supports exact element matching (e.g., "Date") and scoped matching
+ * (e.g., "DayTypeAssignment/Date" — matches "Date" only inside "DayTypeAssignment").
  */
 class PluginRegistry {
     private val plugins: MutableList<NetexPlugin> = mutableListOf()
     private val elementToPluginsMap: MutableMap<String, MutableList<NetexPlugin>> = mutableMapOf()
+    private val scopedElementToPluginsMap: MutableMap<String, MutableList<ScopedPluginMatch>> = mutableMapOf()
 
     /**
      * Registers a plugin with the registry
@@ -17,7 +21,17 @@ class PluginRegistry {
         
         // Update element-to-plugins mapping
         plugin.getSupportedElementTypes().forEach { elementType ->
-            elementToPluginsMap.putOrAddToList(elementType, plugin)
+            if ("/" in elementType) {
+                val parts = elementType.split("/")
+                require(parts.size == 2) {
+                    "Scoped element type must be 'Ancestor/Element', got: $elementType"
+                }
+                val (ancestor, leaf) = parts
+                scopedElementToPluginsMap.getOrPut(leaf) { mutableListOf() }
+                    .add(ScopedPluginMatch(plugin, ancestor))
+            } else {
+                elementToPluginsMap.putOrAddToList(elementType, plugin)
+            }
         }
     }
     
@@ -28,8 +42,14 @@ class PluginRegistry {
         return elementToPluginsMap[elementType] ?: emptyList()
     }
 
+    fun getScopedPluginsForElement(elementType: String): List<ScopedPluginMatch> {
+        return scopedElementToPluginsMap[elementType] ?: emptyList()
+    }
+
     /**
      * Gets all registered plugins
      */
     fun getAllPlugins(): List<NetexPlugin> = plugins
+
+    data class ScopedPluginMatch(val plugin: NetexPlugin, val requiredAncestor: String)
 }

--- a/lib/src/main/java/org/entur/netex/tools/lib/sax/BuildEntityModelSaxHandler.kt
+++ b/lib/src/main/java/org/entur/netex/tools/lib/sax/BuildEntityModelSaxHandler.kt
@@ -71,7 +71,7 @@ class BuildEntityModelSaxHandler private constructor(
                 registerRef(type = qName!!, attributes = attributes)
             }
 
-            pluginRegistry.getPluginsForElement(qName!!).forEach { plugin ->
+            matchingPlugins(qName ?: return).forEach { plugin ->
                 plugin.startElement(qName, attributes, currentEntity())
             }
         }
@@ -83,7 +83,7 @@ class BuildEntityModelSaxHandler private constructor(
         if (shouldIncludeCurrentElement()) {
             val currentElementName = currentElement()?.name
             if (currentElementName != null) {
-                pluginRegistry.getPluginsForElement(currentElementName).forEach { plugin ->
+                matchingPlugins(currentElementName).forEach { plugin ->
                     plugin.characters(currentElementName, ch, start, length)
                 }
             }
@@ -94,7 +94,7 @@ class BuildEntityModelSaxHandler private constructor(
         if (shouldIncludeCurrentElement()) {
             val currentElement = currentElement()
             if (currentElement?.name != null) {
-                pluginRegistry.getPluginsForElement(currentElement.name).forEach { plugin ->
+                matchingPlugins(currentElement.name).forEach { plugin ->
                     plugin.endElement(currentElement.name, currentEntity())
                 }
             }
@@ -113,6 +113,14 @@ class BuildEntityModelSaxHandler private constructor(
         } else {
             pluginRegistry.getAllPlugins().forEach { it.endDocument(file) }
         }
+    }
+
+    private fun matchingPlugins(elementName: String): Set<NetexPlugin> {
+        val direct = pluginRegistry.getPluginsForElement(elementName)
+        val scoped = pluginRegistry.getScopedPluginsForElement(elementName)
+            .filter { elementStack.any { el -> el.name == it.requiredAncestor } }
+            .map { it.plugin }
+        return (direct + scoped).toSet()
     }
 
     private fun nn(value : String?) = value ?: EMPTY

--- a/lib/src/test/java/org/entur/netex/tools/lib/NetexProcessorTest.kt
+++ b/lib/src/test/java/org/entur/netex/tools/lib/NetexProcessorTest.kt
@@ -62,8 +62,8 @@ class NetexProcessorTest {
 
         val result = filter.run(documents)
 
-        assertTrue(result.documents.containsKey("test.xml"))
-        val outputXml = String(result.documents["test.xml"]!!, Charsets.UTF_8)
+        val outputBytes = requireNotNull(result.documents["test.xml"])
+        val outputXml = String(outputBytes, Charsets.UTF_8)
         assertTrue(outputXml.contains("ScheduledStopPoint"))
         assertTrue(outputXml.contains("SSP:1"))
     }
@@ -213,6 +213,100 @@ class NetexProcessorTest {
 
         assertEquals("my-file.xml", plugin.lastDocumentName)
         assertTrue(plugin.receivedFile, "File mode should call endDocument(File)")
+    }
+
+    private val netexWithCoordinates = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <PublicationDelivery xmlns="http://www.netex.org.uk/netex" version="1.0">
+          <dataObjects>
+            <CompositeFrame id="CF:1" version="1">
+              <frames>
+                <ServiceFrame id="SF:1" version="1">
+                  <scheduledStopPoints>
+                    <ScheduledStopPoint id="SSP:1" version="1">
+                      <Name>Central Station</Name>
+                      <Location>
+                        <Longitude>10.75</Longitude>
+                        <Latitude>59.91</Latitude>
+                      </Location>
+                    </ScheduledStopPoint>
+                    <ScheduledStopPoint id="SSP:2" version="1">
+                      <Name>Airport</Name>
+                      <Location>
+                        <Longitude>11.08</Longitude>
+                        <Latitude>60.19</Latitude>
+                      </Location>
+                    </ScheduledStopPoint>
+                  </scheduledStopPoints>
+                </ServiceFrame>
+              </frames>
+            </CompositeFrame>
+          </dataObjects>
+        </PublicationDelivery>
+    """.trimIndent()
+
+    @Test
+    fun `scoped plugin extracts nested coordinates`() {
+        val plugin = ScopedCoordinateExtractorPlugin()
+        val filterConfig = FilterConfig().toBuilder()
+            .withPlugins(listOf(plugin))
+            .build()
+        val processor = NetexProcessor(filterConfig = filterConfig)
+
+        processor.buildEntityModel(mapOf("test.xml" to netexWithCoordinates.toByteArray()))
+
+        @Suppress("UNCHECKED_CAST")
+        val coords = plugin.getCollectedData() as Map<String, Pair<String, String>>
+        assertEquals(2, coords.size)
+        assertEquals("10.75" to "59.91", coords["SSP:1"])
+        assertEquals("11.08" to "60.19", coords["SSP:2"])
+    }
+
+
+    /** Uses scoped registration — separate callbacks per element, no descendant mode needed. */
+    private class ScopedCoordinateExtractorPlugin : AbstractNetexPlugin() {
+        private val coordinates = mutableMapOf<String, Pair<String, String>>()
+        private var currentLon = StringBuilder()
+        private var currentLat = StringBuilder()
+        private var activeField: StringBuilder? = null
+        private var currentStopPointId: String? = null
+
+        override fun getName() = "ScopedCoordinateExtractor"
+        override fun getDescription() = "Extracts coordinates via scoped element registration"
+        override fun getSupportedElementTypes() = setOf(
+            "ScheduledStopPoint",
+            "ScheduledStopPoint/Longitude",
+            "ScheduledStopPoint/Latitude",
+        )
+
+        override fun startElement(elementName: String, attributes: Attributes?, currentEntity: org.entur.netex.tools.lib.model.Entity?) {
+            when (elementName) {
+                "ScheduledStopPoint" -> currentStopPointId = currentEntity?.id
+                "Longitude" -> activeField = currentLon
+                "Latitude" -> activeField = currentLat
+            }
+        }
+
+        override fun characters(elementName: String, ch: CharArray?, start: Int, length: Int) {
+            ch?.let { activeField?.append(it, start, length) }
+        }
+
+        override fun endElement(elementName: String, currentEntity: org.entur.netex.tools.lib.model.Entity?) {
+            when (elementName) {
+                "Longitude", "Latitude" -> activeField = null
+                "ScheduledStopPoint" -> {
+                    val id = currentStopPointId
+                    if (id != null && currentLon.isNotEmpty() && currentLat.isNotEmpty()) {
+                        coordinates[id] = currentLon.toString() to currentLat.toString()
+                    }
+                    currentLon.clear()
+                    currentLat.clear()
+                    currentStopPointId = null
+                }
+            }
+        }
+
+        override fun getCollectedData(): Map<String, Pair<String, String>> = coordinates
     }
 
     private class StopPointCollectorPlugin : AbstractNetexPlugin() {

--- a/lib/src/test/java/org/entur/netex/tools/lib/sax/BuildEntityModelSaxHandlerTest.kt
+++ b/lib/src/test/java/org/entur/netex/tools/lib/sax/BuildEntityModelSaxHandlerTest.kt
@@ -1,13 +1,16 @@
 package org.entur.netex.tools.lib.sax
 
 import org.entur.netex.tools.lib.data.TestDataFactory
+import org.entur.netex.tools.lib.model.Entity
 import org.entur.netex.tools.lib.model.EntityModel
+import org.entur.netex.tools.lib.plugin.AbstractNetexPlugin
 import org.entur.netex.tools.lib.plugin.TestNetexPlugin
 import org.entur.netex.tools.lib.selections.InclusionPolicy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.xml.sax.Attributes
 import java.io.File
 
 class BuildEntityModelSaxHandlerTest {
@@ -208,9 +211,127 @@ class BuildEntityModelSaxHandlerTest {
         Assertions.assertFalse(testNetexPlugin.hasCalledEndElement)
     }
 
+    // --- Scoped element registration tests ---
+
+    @Test
+    fun testUnscopedPluginDoesNotReceiveNestedCallbacks() {
+        val attrs = TestDataFactory.defaultAttributes(id = "id")
+
+        buildEntityModelHandler.startElement("", "", testNetexPlugin.supportedElementType, attrs)
+        testNetexPlugin.reset()
+
+        // Nested child — unscoped plugin should NOT be notified
+        buildEntityModelHandler.startElement("", "", "NestedChild", TestDataFactory.defaultAttributes())
+        Assertions.assertFalse(testNetexPlugin.hasCalledStartElement)
+
+        val chars = "text".toCharArray()
+        buildEntityModelHandler.characters(chars, 0, chars.size)
+        Assertions.assertFalse(testNetexPlugin.hasCalledCharacters)
+
+        buildEntityModelHandler.endElement("", "", "NestedChild")
+        Assertions.assertFalse(testNetexPlugin.hasCalledEndElement)
+    }
+
+    @Test
+    fun testScopedPluginReceivesEventsOnlyInsideAncestor() {
+        val plugin = TrackingPlugin("ParentElement/ChildElement")
+
+        val handler = BuildEntityModelSaxHandler(
+            entityModel = TestDataFactory.defaultEntityModel(),
+            inclusionPolicy = InclusionPolicy(entitySelection = null, refSelection = null, skipElements = emptyList()),
+            file = File("test.xml"),
+            plugins = listOf(plugin),
+        )
+
+        // ChildElement outside ParentElement — should NOT match
+        handler.startElement("", "", "Other", TestDataFactory.defaultAttributes(id = "o1"))
+        handler.startElement("", "", "ChildElement", TestDataFactory.defaultAttributes())
+        handler.endElement("", "", "ChildElement")
+        handler.endElement("", "", "Other")
+
+        Assertions.assertTrue(plugin.events.isEmpty(), "Scoped plugin should not receive events outside ancestor")
+
+        // ChildElement inside ParentElement — should match
+        handler.startElement("", "", "ParentElement", TestDataFactory.defaultAttributes(id = "p1"))
+        handler.startElement("", "", "ChildElement", TestDataFactory.defaultAttributes())
+        val chars = "text".toCharArray()
+        handler.characters(chars, 0, chars.size)
+        handler.endElement("", "", "ChildElement")
+        handler.endElement("", "", "ParentElement")
+
+        Assertions.assertEquals(
+            listOf("startElement:ChildElement", "characters:ChildElement", "endElement:ChildElement"),
+            plugin.events
+        )
+    }
+
+    @Test
+    fun testScopedAndUnscopedPluginsCoexist() {
+        val scopedPlugin = TrackingPlugin("ParentElement/SharedName")
+        val unscopedPlugin = TrackingPlugin("SharedName")
+
+        val handler = BuildEntityModelSaxHandler(
+            entityModel = TestDataFactory.defaultEntityModel(),
+            inclusionPolicy = InclusionPolicy(entitySelection = null, refSelection = null, skipElements = emptyList()),
+            file = File("test.xml"),
+            plugins = listOf(scopedPlugin, unscopedPlugin),
+        )
+
+        // SharedName outside ParentElement — only unscoped should match
+        handler.startElement("", "", "Other", TestDataFactory.defaultAttributes(id = "o1"))
+        handler.startElement("", "", "SharedName", TestDataFactory.defaultAttributes())
+        handler.endElement("", "", "SharedName")
+        handler.endElement("", "", "Other")
+
+        Assertions.assertTrue(scopedPlugin.events.isEmpty())
+        Assertions.assertEquals(
+            listOf("startElement:SharedName", "endElement:SharedName"),
+            unscopedPlugin.events
+        )
+
+        unscopedPlugin.events.clear()
+
+        // SharedName inside ParentElement — both should match
+        handler.startElement("", "", "ParentElement", TestDataFactory.defaultAttributes(id = "p1"))
+        handler.startElement("", "", "SharedName", TestDataFactory.defaultAttributes())
+        handler.endElement("", "", "SharedName")
+        handler.endElement("", "", "ParentElement")
+
+        Assertions.assertEquals(
+            listOf("startElement:SharedName", "endElement:SharedName"),
+            scopedPlugin.events
+        )
+        Assertions.assertEquals(
+            listOf("startElement:SharedName", "endElement:SharedName"),
+            unscopedPlugin.events
+        )
+    }
+
     @AfterEach
     fun tearDown() {
         testNetexPlugin.reset()
+    }
+
+    /** Test plugin that tracks all received events. */
+    private class TrackingPlugin(vararg elementTypes: String) : AbstractNetexPlugin() {
+        private val types = elementTypes.toSet()
+        val events = mutableListOf<String>()
+
+        override fun getName() = "Tracker"
+        override fun getDescription() = "Tracks events for testing"
+        override fun getSupportedElementTypes() = types
+
+        override fun startElement(elementName: String, attributes: Attributes?, currentEntity: Entity?) {
+            events.add("startElement:$elementName")
+        }
+
+        override fun characters(elementName: String, ch: CharArray?, start: Int, length: Int) {
+            events.add("characters:$elementName")
+        }
+
+        override fun endElement(elementName: String, currentEntity: Entity?) {
+            events.add("endElement:$elementName")
+        }
     }
 
 }


### PR DESCRIPTION
Plugins can now use "Ancestor/Element" syntax in getSupportedElementTypes()
to match elements only inside a specific ancestor. This avoids false matches
on generic element names like Date or Name that appear in multiple contexts.

For example, "DayTypeAssignment/Date" matches Date only inside
DayTypeAssignment, and "ScheduledStopPoint/Longitude" matches Longitude
only inside ScheduledStopPoint.

Existing plugins are unaffected — unscoped element types work as before.