### PR TITLE
Add element-injection hooks to XMLElementHandler

### DIFF
--- a/lib/src/main/java/org/entur/netex/tools/lib/output/DelegatingXMLElementWriter.kt
+++ b/lib/src/main/java/org/entur/netex/tools/lib/output/DelegatingXMLElementWriter.kt
@@ -40,6 +40,7 @@ class DelegatingXMLElementWriter(
         val handler = elementHandler(path)
         if (handler != null) {
             handler.startElement(uri, localName, qName, attributes, this)
+            handler.afterStartElement(uri, localName, qName, this)
         } else {
             startElement(uri, localName, qName, attributes)
         }
@@ -59,6 +60,7 @@ class DelegatingXMLElementWriter(
     fun handleEndElement(uri: String?, localName: String?, qName: String?, path: String) {
         val handler = elementHandler(path)
         if (handler != null) {
+            handler.beforeEndElement(uri, localName, qName, this)
             handler.endElement(uri, localName, qName, this)
         } else {
             endElement(uri, localName, qName)

--- a/lib/src/main/java/org/entur/netex/tools/lib/output/XMLElementHandler.kt
+++ b/lib/src/main/java/org/entur/netex/tools/lib/output/XMLElementHandler.kt
@@ -6,4 +6,68 @@ interface XMLElementHandler {
     fun startElement(uri: String?, localName: String?, qName: String?, attributes: Attributes?, writer: DelegatingXMLElementWriter)
     fun characters(ch: CharArray?, start: Int, length: Int, writer: DelegatingXMLElementWriter)
     fun endElement(uri: String?, localName: String?, qName: String?, writer: DelegatingXMLElementWriter)
+
+    /**
+     * Invoked after [startElement] has run, before any child events are processed.
+     * Use this to inject XML content at the beginning of the element's body — for
+     * example, to prepend a required first-child element.
+     *
+     * Emit content via `writer.startElement` / `writer.characters` / `writer.endElement`.
+     * Emitted events are written directly to the underlying XML output; they do NOT
+     * re-enter handler dispatch, so injected content will not recursively trigger
+     * handlers registered on the injected elements' paths.
+     *
+     * Notes for NeTEx consumers:
+     * - Pass the correct namespace URI (e.g. `"http://www.netex.org.uk/netex"`) —
+     *   an empty URI will produce schema-invalid output when the document uses a
+     *   default namespace.
+     * - Respect sibling ordering as defined by the NeTEx schema. Injecting at the
+     *   front of a parent whose schema requires specific first-children can produce
+     *   invalid output; consider registering the handler on a schema-anchored child
+     *   instead.
+     *
+     * Default: no-op.
+     */
+    fun afterStartElement(
+        uri: String?,
+        localName: String?,
+        qName: String?,
+        writer: DelegatingXMLElementWriter,
+    ) {
+    }
+
+    /**
+     * Invoked after all child events have been processed, before [endElement] runs.
+     * Use this to inject XML content at the end of the element's body — for example,
+     * to append new children to a container such as appending `<ServiceLink>` entries
+     * to an existing `<serviceLinks>` section.
+     *
+     * Emit content via `writer.startElement` / `writer.characters` / `writer.endElement`.
+     * Emitted events are written directly to the underlying XML output; they do NOT
+     * re-enter handler dispatch.
+     *
+     * For elements subject to deferral via `ParentsWithRequiredChildrenDeferEventsRule`,
+     * this hook fires when the buffered events are flushed, not during SAX parsing.
+     * It does not fire for deferred elements that are discarded because their required
+     * children were missing.
+     *
+     * Notes for NeTEx consumers:
+     * - Pass the correct namespace URI — see [afterStartElement].
+     * - To inject at a schema-correct position between siblings (rather than at the
+     *   very end of the parent), register the handler on a preceding sibling instead
+     *   and emit the new section after calling `writer.endElement(...)` in
+     *   [endElement].
+     * - If the source may already contain a sibling you'd otherwise create (e.g.
+     *   injecting `<serviceLinks>` when it might exist), track child-element events
+     *   in [startElement] / [endElement] to avoid producing duplicates.
+     *
+     * Default: no-op.
+     */
+    fun beforeEndElement(
+        uri: String?,
+        localName: String?,
+        qName: String?,
+        writer: DelegatingXMLElementWriter,
+    ) {
+    }
 }

--- a/lib/src/test/java/org/entur/netex/tools/lib/NetexProcessorTest.kt
+++ b/lib/src/test/java/org/entur/netex/tools/lib/NetexProcessorTest.kt
@@ -1,11 +1,14 @@
 package org.entur.netex.tools.lib
 
 import org.entur.netex.tools.lib.config.FilterConfig
+import org.entur.netex.tools.lib.output.DelegatingXMLElementWriter
+import org.entur.netex.tools.lib.output.XMLElementHandler
 import org.entur.netex.tools.lib.plugin.AbstractNetexPlugin
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.xml.sax.Attributes
+import org.xml.sax.helpers.AttributesImpl
 import java.io.File
 
 class NetexProcessorTest {
@@ -262,6 +265,154 @@ class NetexProcessorTest {
         assertEquals("11.08" to "60.19", coords["SSP:2"])
     }
 
+
+    @Test
+    fun `beforeEndElement hook injects new sibling elements before container closes`() {
+        val containerPath = "/PublicationDelivery/dataObjects/CompositeFrame/frames/ServiceFrame/scheduledStopPoints"
+        val injector = PassThroughWithInjectionHandler { writer ->
+            val attrs = AttributesImpl().apply {
+                addAttribute("", "id", "id", "CDATA", "SSP:INJECTED")
+                addAttribute("", "version", "version", "CDATA", "1")
+            }
+            writer.startElement(NETEX_NS, "ScheduledStopPoint", "ScheduledStopPoint", attrs)
+            writer.endElement(NETEX_NS, "ScheduledStopPoint", "ScheduledStopPoint")
+        }
+
+        val filterConfig = FilterConfig().toBuilder()
+            .withCustomElementHandlers(mapOf(containerPath to injector))
+            .build()
+        val processor = NetexProcessor(filterConfig = filterConfig)
+        val documents = mapOf("test.xml" to minimalNetexXml.toByteArray())
+
+        val result = processor.run(documents)
+
+        val outputXml = String(requireNotNull(result.documents["test.xml"]), Charsets.UTF_8)
+        assertTrue(outputXml.contains("SSP:INJECTED"), "Injected element should appear in output: $outputXml")
+        // Injected element should come after the original children and before </scheduledStopPoints>
+        val ssp2Index = outputXml.indexOf("SSP:2")
+        val injectedIndex = outputXml.indexOf("SSP:INJECTED")
+        val closeTagIndex = outputXml.indexOf("</scheduledStopPoints>")
+        assertTrue(ssp2Index in 0 until injectedIndex, "Injected element should follow existing children")
+        assertTrue(injectedIndex < closeTagIndex, "Injected element should precede closing tag")
+    }
+
+    @Test
+    fun `hooks fire in correct order for nested handlers`() {
+        val parentPath = "/PublicationDelivery/dataObjects/CompositeFrame/frames/ServiceFrame/scheduledStopPoints"
+        val childPath = "$parentPath/ScheduledStopPoint"
+        val trace = mutableListOf<String>()
+        val parent = TracingHandler("scheduledStopPoints", trace)
+        val child = TracingHandler("ScheduledStopPoint", trace)
+
+        val filterConfig = FilterConfig().toBuilder()
+            .withCustomElementHandlers(mapOf(parentPath to parent, childPath to child))
+            .build()
+        val processor = NetexProcessor(filterConfig = filterConfig)
+        val documents = mapOf("test.xml" to minimalNetexXml.toByteArray())
+
+        processor.run(documents)
+
+        // Expected ordering for one parent with two children:
+        //   parent.startElement, parent.afterStartElement,
+        //     child1.startElement, child1.afterStartElement, child1.beforeEndElement, child1.endElement,
+        //     child2.startElement, child2.afterStartElement, child2.beforeEndElement, child2.endElement,
+        //   parent.beforeEndElement, parent.endElement
+        assertEquals(
+            listOf(
+                "scheduledStopPoints:startElement",
+                "scheduledStopPoints:afterStartElement",
+                "ScheduledStopPoint:startElement",
+                "ScheduledStopPoint:afterStartElement",
+                "ScheduledStopPoint:beforeEndElement",
+                "ScheduledStopPoint:endElement",
+                "ScheduledStopPoint:startElement",
+                "ScheduledStopPoint:afterStartElement",
+                "ScheduledStopPoint:beforeEndElement",
+                "ScheduledStopPoint:endElement",
+                "scheduledStopPoints:beforeEndElement",
+                "scheduledStopPoints:endElement",
+            ),
+            trace,
+        )
+    }
+
+    @Test
+    fun `beforeEndElement hook fires for deferred elements when their required children are present`() {
+        // ScheduledStopPoint is deferred until its child Name is seen; when flushed, hooks must fire.
+        val handlerPath = "/PublicationDelivery/dataObjects/CompositeFrame/frames/ServiceFrame/scheduledStopPoints/ScheduledStopPoint"
+        val injector = PassThroughWithInjectionHandler { writer ->
+            writer.startElement(NETEX_NS, "ShortName", "ShortName", AttributesImpl())
+            val text = "INJECTED".toCharArray()
+            writer.characters(text, 0, text.size)
+            writer.endElement(NETEX_NS, "ShortName", "ShortName")
+        }
+        val filterConfig = FilterConfig().toBuilder()
+            .withCustomElementHandlers(mapOf(handlerPath to injector))
+            .withElementsRequiredChildren(mapOf("ScheduledStopPoint" to listOf("Name")))
+            .build()
+        val processor = NetexProcessor(filterConfig = filterConfig)
+        val documents = mapOf("test.xml" to minimalNetexXml.toByteArray())
+
+        val result = processor.run(documents)
+
+        val outputXml = String(requireNotNull(result.documents["test.xml"]), Charsets.UTF_8)
+        // One <ShortName>INJECTED</ShortName> for each ScheduledStopPoint (two in total).
+        val count = Regex("<ShortName[^>]*>INJECTED</ShortName>").findAll(outputXml).count()
+        assertEquals(2, count, "beforeEndElement should fire once per deferred element on flush: $outputXml")
+    }
+
+    private companion object {
+        const val NETEX_NS = "http://www.netex.org.uk/netex"
+    }
+
+    /** Passes source events through unchanged and runs [inject] in beforeEndElement. */
+    private class PassThroughWithInjectionHandler(
+        private val inject: (DelegatingXMLElementWriter) -> Unit,
+    ) : XMLElementHandler {
+        override fun startElement(uri: String?, localName: String?, qName: String?, attributes: Attributes?, writer: DelegatingXMLElementWriter) {
+            writer.startElement(uri, localName, qName, attributes)
+        }
+
+        override fun characters(ch: CharArray?, start: Int, length: Int, writer: DelegatingXMLElementWriter) {
+            writer.characters(ch, start, length)
+        }
+
+        override fun endElement(uri: String?, localName: String?, qName: String?, writer: DelegatingXMLElementWriter) {
+            writer.endElement(uri, localName, qName)
+        }
+
+        override fun beforeEndElement(uri: String?, localName: String?, qName: String?, writer: DelegatingXMLElementWriter) {
+            inject(writer)
+        }
+    }
+
+    /** Records which callbacks fired, tagged with a label, for ordering assertions. */
+    private class TracingHandler(
+        private val label: String,
+        private val trace: MutableList<String>,
+    ) : XMLElementHandler {
+        override fun startElement(uri: String?, localName: String?, qName: String?, attributes: Attributes?, writer: DelegatingXMLElementWriter) {
+            trace += "$label:startElement"
+            writer.startElement(uri, localName, qName, attributes)
+        }
+
+        override fun afterStartElement(uri: String?, localName: String?, qName: String?, writer: DelegatingXMLElementWriter) {
+            trace += "$label:afterStartElement"
+        }
+
+        override fun characters(ch: CharArray?, start: Int, length: Int, writer: DelegatingXMLElementWriter) {
+            writer.characters(ch, start, length)
+        }
+
+        override fun beforeEndElement(uri: String?, localName: String?, qName: String?, writer: DelegatingXMLElementWriter) {
+            trace += "$label:beforeEndElement"
+        }
+
+        override fun endElement(uri: String?, localName: String?, qName: String?, writer: DelegatingXMLElementWriter) {
+            trace += "$label:endElement"
+            writer.endElement(uri, localName, qName)
+        }
+    }
 
     /** Uses scoped registration — separate callbacks per element, no descendant mode needed. */
     private class ScopedCoordinateExtractorPlugin : AbstractNetexPlugin() {

--- a/lib/src/test/java/org/entur/netex/tools/lib/output/DelegatingXMLElementWriterTest.kt
+++ b/lib/src/test/java/org/entur/netex/tools/lib/output/DelegatingXMLElementWriterTest.kt
@@ -78,6 +78,19 @@ class DelegatingXMLElementWriterTest {
     }
 
     @Test
+    fun testHandleStartElementInvokesAfterStartElementHook() {
+        writer.handleStartElement(uri, localName, qName, attrs, customPath)
+        assertTrue { customHandler.hasCalledAfterStartElement }
+        assertEquals(listOf("startElement", "afterStartElement"), customHandler.callOrder)
+    }
+
+    @Test
+    fun testHandleStartElementDoesNotInvokeAfterStartElementHookWhenNoHandlerMatches() {
+        writer.handleStartElement(uri, localName, qName, attrs, defaultPath)
+        assertFalse { customHandler.hasCalledAfterStartElement }
+    }
+
+    @Test
     fun testHandleCharactersCallsCustomHandlerWhenPathsMatch() {
         writer.handleCharacters(ch, 0, length, customPath)
         assertTrue { customHandler.hasCalledCharacters }
@@ -89,6 +102,19 @@ class DelegatingXMLElementWriterTest {
         writer.handleEndElement(uri, localName, qName, customPath)
         assertTrue { customHandler.hasCalledEndElement }
         verifyNoInteractions(defaultHandler)
+    }
+
+    @Test
+    fun testHandleEndElementInvokesBeforeEndElementHook() {
+        writer.handleEndElement(uri, localName, qName, customPath)
+        assertTrue { customHandler.hasCalledBeforeEndElement }
+        assertEquals(listOf("beforeEndElement", "endElement"), customHandler.callOrder)
+    }
+
+    @Test
+    fun testHandleEndElementDoesNotInvokeBeforeEndElementHookWhenNoHandlerMatches() {
+        writer.handleEndElement(uri, localName, qName, defaultPath)
+        assertFalse { customHandler.hasCalledBeforeEndElement }
     }
 
     @Test

--- a/lib/src/test/java/org/entur/netex/tools/lib/output/TestXMLElementHandler.kt
+++ b/lib/src/test/java/org/entur/netex/tools/lib/output/TestXMLElementHandler.kt
@@ -4,8 +4,15 @@ import org.xml.sax.Attributes
 
 class TestXMLElementHandler: XMLElementHandler {
     var hasCalledStartElement = false
+    var hasCalledAfterStartElement = false
     var hasCalledCharacters = false
+    var hasCalledBeforeEndElement = false
     var hasCalledEndElement = false
+
+    /**
+     * Order in which callbacks fired, for verifying dispatch ordering.
+     */
+    val callOrder: MutableList<String> = mutableListOf()
 
     override fun startElement(
         uri: String?,
@@ -15,6 +22,17 @@ class TestXMLElementHandler: XMLElementHandler {
         writer: DelegatingXMLElementWriter
     ) {
         hasCalledStartElement = true
+        callOrder += "startElement"
+    }
+
+    override fun afterStartElement(
+        uri: String?,
+        localName: String?,
+        qName: String?,
+        writer: DelegatingXMLElementWriter
+    ) {
+        hasCalledAfterStartElement = true
+        callOrder += "afterStartElement"
     }
 
     override fun characters(
@@ -24,6 +42,17 @@ class TestXMLElementHandler: XMLElementHandler {
         writer: DelegatingXMLElementWriter
     ) {
         hasCalledCharacters = true
+        callOrder += "characters"
+    }
+
+    override fun beforeEndElement(
+        uri: String?,
+        localName: String?,
+        qName: String?,
+        writer: DelegatingXMLElementWriter
+    ) {
+        hasCalledBeforeEndElement = true
+        callOrder += "beforeEndElement"
     }
 
     override fun endElement(
@@ -33,11 +62,15 @@ class TestXMLElementHandler: XMLElementHandler {
         writer: DelegatingXMLElementWriter
     ) {
         hasCalledEndElement = true
+        callOrder += "endElement"
     }
 
     fun reset() {
         hasCalledStartElement = false
+        hasCalledAfterStartElement = false
         hasCalledCharacters = false
+        hasCalledBeforeEndElement = false
         hasCalledEndElement = false
+        callOrder.clear()
     }
 }


### PR DESCRIPTION
Adds afterStartElement and beforeEndElement default-no-op methods to XMLElementHandler, enabling handlers to inject new sibling elements at the start or end of the element they are registered on. Fully additive — existing handlers (e.g. SkipElementHandler) need no change.

Covers the last API gap servicelinker needs for its Pass 2 injection pipeline (see [netex-tools-migration.md, Must-have #4](https://github.com/entur/servicelinker/blob/c902e229ae5535fda1cbc2141bfe0c9bae47ba61/docs/netex-tools-migration.md#must-have)).