### PR TITLE
Implements CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,192 +39,106 @@ See `FilterNetexApp_README.md` for full API documentation, or the tests for usag
 
 ## netex-tools-cli
 
-A java main that takes 3 arguments:
- - A config file with filtering rules
- - An input source (directory, zip not supported yet)
- - An output dir
+A command-line tool for filtering NeTEx datasets using JSON config files.
 
+### Prerequisites
 
-### config file
+- Java 21 or later
+- Maven 3.x (only required to build from source)
 
-Note! The parser does not accept comment, so you need to remove the comments
-to use the example below.
+### Installation
+
+Clone the repository and build the CLI module:
+
+```bash
+git clone https://github.com/entur/netex-tools.git
+cd netex-tools
+./mvnw package -pl cli --also-make
+```
+
+This produces:
+- `cli/target/netex-tools-cli-<version>.jar` — the CLI application
+- `cli/target/dependency/` — all runtime dependencies
+
+The shell wrapper at `bin/netex-tools` assembles the classpath automatically.
+Optionally add `bin/` to your `PATH`, or create a symlink:
+
+```bash
+ln -s "$(pwd)/bin/netex-tools" /usr/local/bin/netex-tools
+```
+
+### Usage
+
+```
+netex-tools filter [options]
+
+Options:
+  --filter-config PATH   Path to filter config JSON file (required)
+  --input PATH           Input directory containing NeTEx XML files (required)
+  --output PATH          Output directory for filtered NeTEx XML files (required)
+  --cli-config PATH      Path to CLI config JSON file (optional; uses defaults if omitted)
+  -h, --help             Show help and exit
+```
+
+**Example — filter with default CLI settings:**
+
+```bash
+netex-tools filter \
+  --filter-config filter-config.json \
+  --input path/to/netex-input/ \
+  --output path/to/filtered-output/
+```
+
+**Example — filter with custom CLI settings (log level, report, aliases):**
+
+```bash
+netex-tools filter \
+  --cli-config cli-config.json \
+  --filter-config filter-config.json \
+  --input path/to/netex-input/ \
+  --output path/to/filtered-output/
+```
+
+### Config files
+
+**cli-config.json** (optional) — controls log level, report, and aliases:
 
 ```json
 {
-  "logLevel" : "INFO",
-  
-  "doc1" :  "Print a report with entities and relations witch summarize the number of selected entities and the total number of entities in the datasource.",
-  "printReport" : true,
-  
-  "doc2" :  "NOT IMPLEMENTED!", 
-  "doc3" :  "Keep all locations (Quays, StopPlaces ...) inside the polygon/bounding box defined by the coordinates. StopPlaces are kept if one quay is inside the area.",
-  "area" : "60.0 10.0 60.0 10.0",
+  "logLevel": "INFO",
+  "printReport": true,
+  "alias": {
+    "CompositeFrame": "CF",
+    "ResourceFrame": "RF",
+    "ServiceCalendarFrame": "SCF",
+    "ServiceFrame": "SF",
+    "Network": "NW",
+    "TimetableFrame": "TF",
+    "SiteFrame": "SF",
+    "StopPointInJourneyPattern": "SPInJP"
+  }
+}
+```
 
-  "doc4" :  "NOT IMPLEMENTED!", 
-  "doc5" :  "Include services witch operate in period (inclusive, exclusive)",
-  "period" : {
-    "start" : "2024-01-01",
-    "end" : "2024-12-31"
-  },
-  
-  "doc6" :  "Include the following lines, these are merged with the serviceJourneys and flex-lines",
-  "lines" : [
-    "NNN:Line:500"
-  ],
-  
-  "doc7" :  "Include the following service journeys, these are merged with the lines and flex-lines",
-  "serviceJourneys" : [
-    "NNN:ServiceJourney:310_12"
-  ],
-  
-  "doc8" :  "Include the following flexible lines, these are merged with the lines and service journeys",
-  "flexLines" : [
-    "NNN:FlexLine:1"
-  ],
-  
-  "doc9" : "These elements are skipped, nested elements are skipped as well. The list included here is are all not parsed by OTP or optional (Notice).", 
-  "skipElements" : [
-    "AccessibilityAssessment",
-    "AlternativeName",
-    "keyList",
-    "FromPointRef",
-    "GroupOfStopPlaces",
-    "NoticeAssignment",
-    "NoticeRef",
-    "NoticedObjectRef",
-    "Parking",
-    "ParkingProperties",
-    "placeEquipments",
-    "ServiceLink",
-    "TopographicPlace",
-    "TopographicPlaceRef",
-    "TariffZone",
-    "TariffZoneRef",
-    "ToPointRef"
-  ],
-  
-  "doc10" :  "The alias is used in the report only to shorten the lines",
-  "alias" : [
-    "CompositeFrame CF",
-    "ResourceFrame RF",
-    "ServiceCalendarFrame SCF",
-    "ServiceFrame SF",
-    "Network NW",
-    "TimetableFrame TTF",
-    "SiteFrame SF",
-    "StopPointInJourneyPattern SPInJP"
+**filter-config.json** (required) — controls what gets filtered, pruned, and transformed.
+See [FilterNetexApp_README.md](FilterNetexApp_README.md) for the full `FilterConfig` reference.
+
+Minimal example:
+
+```json
+{
+  "pruneReferences": true,
+  "unreferencedEntitiesToPrune": [
+    "JourneyPattern", "Route", "Network", "Line",
+    "Operator", "Notice", "DestinationDisplay", "ServiceLink"
   ]
 }
 ```
 
-An entity is only kept if all fliter rules are satisfied. If no filter rule is defined for a type, 
-the normal cascade deleting applies.
+### Note on distribution
 
-#### Report
-The cli will by default print a report. The report contains a _count_ and the total in the source data for the 
-selected entities and relationships. The report is useful when setting up a new filter and can also be used to analyze
-the data entity/relationships.
-
-<details>
-  <summary>Example entity/relationship report</summary>
-
-The alias in the config file is used in the report. For example, `CF`in the report means `CompositeFrame`.  
-
-```
-SELECTED ENTITIES
-
-CF                                                    2      4
-CF/AvailabilityCondition                              ·      4
-CF/Codespace                                          ·      2
-CF/RF                                                 1      2
-CF/RF/Authority                                       ·      1
-CF/RF/Operator                                        1     12
-CF/SCF                                                1      2
-CF/SCF/DayType                                        1    372
-CF/SCF/DayTypeAssignment                              8   5345
-CF/SCF/OperatingPeriod                                1   1492
-CF/SF                                                 2      5
-CF/SF/DestinationDisplay                              2   1638
-CF/SF/FlexibleLine                                    ·      1
-CF/SF/FlexibleStopAssignment                          ·    316
-CF/SF/FlexibleStopPlace                               ·    316
-CF/SF/FlexibleStopPlace/FlexibleArea                  ·    316
-CF/SF/JourneyPattern                                  1     24
-CF/SF/JourneyPattern/SPInJP                          30    638
-CF/SF/JourneyPattern/ServiceLinkInJourneyPattern      ·    613
-CF/SF/Line                                            1      1
-CF/SF/NW                                              1      2
-CF/SF/NW/GroupOfLines                                 1      3
-CF/SF/Notice                                          ·    101
-CF/SF/PassengerStopAssignment                        30   8699
-CF/SF/Route                                           1     24
-CF/SF/Route/PointOnRoute                              ·    638
-CF/SF/RoutePoint                                      ·   9015
-CF/SF/RoutePoint/PointProjection                      ·   9015
-CF/SF/ScheduledStopPoint                             30   9015
-CF/TTF                                                1      2
-CF/TTF/ServiceJourney                                 1    134
-CF/TTF/ServiceJourney/FlexibleServiceProperties       ·      2
-CF/TTF/ServiceJourney/TimetabledPassingTime          30   3866
-CF/TTF/ServiceJourneyInterchange                      ·     56
-RF                                                    ·      1
-RF/PurposeOfGrouping                                  ·      1
-SF                                                    1      1
-SF/StopPlace                                         30   5760
-SF/StopPlace/Quay                                    30  10621
-SF/StopPlace/Quay/BoardingPosition                    ·     68
-
-
-
-SELECTED REFERENCES
-
-AuthorityRef CF/SF/NW -> CF/RF/Authority                                                  ·      2
-DayTypeRef CF/SCF/DayTypeAssignment -> CF/SCF/DayType                                     8   5345
-DayTypeRef CF/TTF/ServiceJourney -> CF/SCF/DayType                                        1    134
-DestinationDisplayRef CF/SF/JourneyPattern/SPInJP -> CF/SF/DestinationDisplay             2     39
-FlexibleLineRef CF/SF/Route -> CF/SF/FlexibleLine                                         ·      1
-FlexibleStopPlaceRef CF/SF/FlexibleStopAssignment -> CF/SF/FlexibleStopPlace              ·    316
-FromJourneyRef CF/TTF/ServiceJourneyInterchange -> Ø                                      ·     56
-JourneyPatternRef CF/TTF/ServiceJourney -> CF/SF/JourneyPattern                           1    134
-LineRef CF/SF/Route -> CF/SF/Line                                                         1     23
-LineRef CF/TTF/ServiceJourney -> CF/SF/Line                                               1    132
-OperatingPeriodRef CF/SCF/DayTypeAssignment -> CF/SCF/OperatingPeriod                     1   1492
-OperatorRef CF/SF/FlexibleLine -> CF/RF/Operator                                          ·      1
-OperatorRef CF/SF/Line -> CF/RF/Operator                                                  1      1
-OperatorRef CF/TTF/ServiceJourney -> CF/RF/Operator                                       1    132
-ParentSiteRef SF/StopPlace -> SF/StopPlace                                                ·    173
-ProjectToPointRef CF/SF/RoutePoint/PointProjection -> CF/SF/ScheduledStopPoint            ·    316
-ProjectedPointRef CF/SF/RoutePoint/PointProjection -> CF/SF/ScheduledStopPoint            ·   8699
-QuayRef CF/SF/PassengerStopAssignment -> SF/StopPlace/Quay                               30   8677
-QuayRef CF/SF/PassengerStopAssignment -> Ø                                                ·     22
-RepresentedByGroupRef CF/SF/FlexibleLine -> CF/SF/NW                                      ·      1
-RepresentedByGroupRef CF/SF/Line -> CF/SF/NW/GroupOfLines                                 1      1
-RoutePointRef CF/SF/Route/PointOnRoute -> CF/SF/RoutePoint                                ·    638
-RouteRef CF/SF/JourneyPattern -> CF/SF/Route                                              1     24
-SPInJPRef CF/TTF/ServiceJourney/TimetabledPassingTime -> CF/SF/JourneyPattern/SPInJP     30   3866
-ScheduledStopPointRef CF/SF/FlexibleStopAssignment -> CF/SF/ScheduledStopPoint            ·    316
-ScheduledStopPointRef CF/SF/JourneyPattern/SPInJP -> CF/SF/ScheduledStopPoint            30    638
-ScheduledStopPointRef CF/SF/PassengerStopAssignment -> CF/SF/ScheduledStopPoint          30   8699
-ServiceLinkRef CF/SF/JourneyPattern/ServiceLinkInJourneyPattern -> Ø                      ·    613
-SiteRef SF/StopPlace -> SF/StopPlace                                                      ·      6
-ToJourneyRef CF/TTF/ServiceJourneyInterchange -> CF/TTF/ServiceJourney                    ·     56
-```
-
-</details>
-
-
-#### Algorithm outline
-
-1. Apply all rules to the data set.
-   1. For example, filter quays and stop-places based on the `location-box`, `quay-ids`, and `line-ids`.
-   2. Filter lines if `line-ids` is defined.
-   3. Filter day-types and dated-service-journeys based on `period`
-2. Merge and filter relations. 
-3. Parse the data again and output selected entities and all child elements, but not necessarily child 
-   entities.
-   
-This diagram might help with filtering relations:
-
-![Netex overview](images/NetexOverview.png)
+The CLI is distributed as a thin JAR (published to Maven Central) alongside its
+dependencies. Users build from source with `./mvnw package` to get a runnable
+installation. A fat JAR (standalone executable) is not published; the shell wrapper
+handles classpath assembly.
 

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Minimal example:
 
 ### Note on distribution
 
-The CLI is distributed as a thin JAR (published to Maven Central) alongside its
-dependencies. Users build from source with `./mvnw package` to get a runnable
-installation. A fat JAR (standalone executable) is not published; the shell wrapper
-handles classpath assembly.
+The CLI is **not** published to Maven Central (`maven.deploy.skip=true`). Build it
+from source with `./mvnw package -pl cli --also-make` to get a thin JAR in `cli/target/`
+alongside its dependencies in `cli/target/dependency/`. A fat JAR (standalone executable)
+is not produced; the `bin/netex-tools` wrapper assembles the classpath.
 

--- a/bin/netex-tools
+++ b/bin/netex-tools
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" = /* ]] || SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CLI_TARGET="$PROJECT_ROOT/cli/target"
 

--- a/bin/netex-tools
+++ b/bin/netex-tools
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLI_TARGET="$PROJECT_ROOT/cli/target"
+
+CLI_JAR=$(find "$CLI_TARGET" -maxdepth 1 -name "netex-tools-cli-*.jar" \
+    ! -name "*-sources.jar" ! -name "*-javadoc.jar" 2>/dev/null | sort -V | tail -1)
+
+if [[ -z "$CLI_JAR" ]]; then
+    echo "Error: netex-tools-cli JAR not found in $CLI_TARGET" >&2
+    echo "Build the project first: ./mvnw package -pl cli --also-make" >&2
+    exit 1
+fi
+
+DEPS_DIR="$CLI_TARGET/dependency"
+
+if [[ ! -d "$DEPS_DIR" ]]; then
+    echo "Error: Dependencies not found in $DEPS_DIR" >&2
+    echo "Build the project first: ./mvnw package -pl cli --also-make" >&2
+    exit 1
+fi
+
+exec java -cp "$CLI_JAR:$DEPS_DIR/*" org.entur.netex.tools.cli.MainKt "$@"

--- a/bin/netex-tools
+++ b/bin/netex-tools
@@ -12,7 +12,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CLI_TARGET="$PROJECT_ROOT/cli/target"
 
 CLI_JAR=$(find "$CLI_TARGET" -maxdepth 1 -name "netex-tools-cli-*.jar" \
-    ! -name "*-sources.jar" ! -name "*-javadoc.jar" 2>/dev/null | sort -V | tail -1)
+    ! -name "*-sources.jar" ! -name "*-javadoc.jar" 2>/dev/null | sort -V | tail -1 || true)
 
 if [[ -z "$CLI_JAR" ]]; then
     echo "Error: netex-tools-cli JAR not found in $CLI_TARGET" >&2

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -11,9 +11,13 @@
 
     <artifactId>netex-tools-cli</artifactId>
     <name>netex-tools-cli</name>
-    <description>netex tools cli</description>
+    <description>NeTEx Tools CLI — not published to Maven Central. Clone the repo and build with ./mvnw package -pl cli --also-make, then use bin/netex-tools.</description>
     <url>https://github.com/entur/netex-tools</url>
     <packaging>jar</packaging>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -21,5 +25,33 @@
             <artifactId>netex-tools-lib</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.ajalt.clikt</groupId>
+            <artifactId>clikt-jvm</artifactId>
+            <version>4.4.0</version>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/dependency</outputDirectory>
+                            <includeScope>runtime</includeScope>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/cli/src/main/java/org/entur/netex/tools/cli/FilterCommand.kt
+++ b/cli/src/main/java/org/entur/netex/tools/cli/FilterCommand.kt
@@ -1,0 +1,40 @@
+package org.entur.netex.tools.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+import org.entur.netex.tools.cli.app.FilterNetexApp
+import org.entur.netex.tools.lib.config.CliConfig
+import org.entur.netex.tools.lib.config.JsonConfig
+
+class FilterCommand : CliktCommand(
+    name = "filter",
+    help = "Filter a NeTEx dataset and write the result to an output directory."
+) {
+    private val cliConfigFile by option(
+        "--cli-config",
+        help = "Path to CLI config JSON file (optional). If omitted, defaults are used."
+    ).file(mustExist = true, canBeDir = false)
+
+    private val filterConfigFile by option(
+        "--filter-config",
+        help = "Path to filter config JSON file."
+    ).file(mustExist = true, canBeDir = false).required()
+
+    private val input by option(
+        "--input",
+        help = "Input directory containing NeTEx XML files."
+    ).file(mustExist = true, canBeDir = true, canBeFile = false).required()
+
+    private val output by option(
+        "--output",
+        help = "Output directory for filtered NeTEx XML files. Created if it does not exist."
+    ).file().required()
+
+    override fun run() {
+        val cliConfig = cliConfigFile?.inputStream()?.use { JsonConfig.loadCliConfig(it) } ?: CliConfig()
+        val filterConfig = filterConfigFile.inputStream().use { JsonConfig.loadFilterConfig(it) }
+        FilterNetexApp(cliConfig, filterConfig, input, target = output).run()
+    }
+}

--- a/cli/src/main/java/org/entur/netex/tools/cli/Main.kt
+++ b/cli/src/main/java/org/entur/netex/tools/cli/Main.kt
@@ -1,44 +1,18 @@
 package org.entur.netex.tools.cli
 
-import org.entur.netex.tools.cli.app.FilterNetexApp
-import org.entur.netex.tools.lib.config.JsonConfig
-import java.io.File
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
 
+fun main(args: Array<String>) = NetexToolsCli().main(args)
 
-fun main(args : Array<String>) {
-    if(args.size != 4) {
-        printHelp()
-        return
+class NetexToolsCli : CliktCommand(
+    name = "netex-tools",
+    help = "NeTEx Tools — utilities for parsing, filtering, and transforming NeTEx data.",
+    printHelpOnEmptyArgs = true,
+) {
+    init {
+        subcommands(FilterCommand())
     }
 
-    val cliConfig = File(args[0])
-        .inputStream()
-        .use {
-            inputStream -> JsonConfig.loadCliConfig(inputStream)
-        }
-
-    val filterConfig = File(args[1])
-        .inputStream()
-        .use {
-            inputStream -> JsonConfig.loadFilterConfig(inputStream)
-        }
-
-    val app = FilterNetexApp(
-        cliConfig,
-        filterConfig,
-        File(args[2]),
-        File(args[3])
-    )
-    app.run()
+    override fun run() = Unit
 }
-
-fun printHelp() {
-    println("""
-    The app takes 4 arguments: 
-       - <cli-config-file-name>      : The name of the configuration file for CLI, relative to the local directory.
-       - <filter-config-file-name>   : The name of the configuration file for filters, relative to the local directory.
-       - <netex-input-directory> : The file folder to read Netex data from (Zip not supported, extract).
-       - <output-directory>      : The location for the output.     
-    """.trimIndent())
-}
-

--- a/cli/src/test/java/org/entur/netex/tools/cli/FilterCommandTest.kt
+++ b/cli/src/test/java/org/entur/netex/tools/cli/FilterCommandTest.kt
@@ -1,0 +1,38 @@
+package org.entur.netex.tools.cli
+
+import com.github.ajalt.clikt.core.CliktError
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class FilterCommandTest {
+
+    @TempDir
+    lateinit var tmpDir: File
+
+    private val filterConfigJson get() = File(tmpDir, "filter-config.json").also { it.writeText("{}") }
+    private val inputDir get() = File(tmpDir, "input").also { it.mkdir() }
+    private val outputDir get() = File(tmpDir, "output")
+
+    @Test
+    fun `filter command requires --filter-config`() {
+        assertThrows<CliktError> {
+            NetexToolsCli().parse(listOf("filter", "--input", inputDir.absolutePath, "--output", outputDir.absolutePath))
+        }
+    }
+
+    @Test
+    fun `filter command requires --input`() {
+        assertThrows<CliktError> {
+            NetexToolsCli().parse(listOf("filter", "--filter-config", filterConfigJson.absolutePath, "--output", outputDir.absolutePath))
+        }
+    }
+
+    @Test
+    fun `filter command requires --output`() {
+        assertThrows<CliktError> {
+            NetexToolsCli().parse(listOf("filter", "--filter-config", filterConfigJson.absolutePath, "--input", inputDir.absolutePath))
+        }
+    }
+}

--- a/cli/src/test/java/org/entur/netex/tools/cli/FilterCommandTest.kt
+++ b/cli/src/test/java/org/entur/netex/tools/cli/FilterCommandTest.kt
@@ -1,6 +1,8 @@
 package org.entur.netex.tools.cli
 
-import com.github.ajalt.clikt.core.CliktError
+import com.github.ajalt.clikt.core.MissingOption
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
@@ -11,28 +13,56 @@ class FilterCommandTest {
     @TempDir
     lateinit var tmpDir: File
 
-    private val filterConfigJson get() = File(tmpDir, "filter-config.json").also { it.writeText("{}") }
-    private val inputDir get() = File(tmpDir, "input").also { it.mkdir() }
-    private val outputDir get() = File(tmpDir, "output")
+    private lateinit var filterConfig: File
+    private lateinit var inputDir: File
+    private lateinit var outputDir: File
+
+    @BeforeEach
+    fun setUp() {
+        filterConfig = File(tmpDir, "filter-config.json").apply { writeText("{}") }
+        inputDir = File(tmpDir, "input").apply { mkdir() }
+        outputDir = File(tmpDir, "output")
+    }
 
     @Test
     fun `filter command requires --filter-config`() {
-        assertThrows<CliktError> {
+        assertThrows<MissingOption> {
             NetexToolsCli().parse(listOf("filter", "--input", inputDir.absolutePath, "--output", outputDir.absolutePath))
         }
     }
 
     @Test
     fun `filter command requires --input`() {
-        assertThrows<CliktError> {
-            NetexToolsCli().parse(listOf("filter", "--filter-config", filterConfigJson.absolutePath, "--output", outputDir.absolutePath))
+        assertThrows<MissingOption> {
+            NetexToolsCli().parse(listOf("filter", "--filter-config", filterConfig.absolutePath, "--output", outputDir.absolutePath))
         }
     }
 
     @Test
     fun `filter command requires --output`() {
-        assertThrows<CliktError> {
-            NetexToolsCli().parse(listOf("filter", "--filter-config", filterConfigJson.absolutePath, "--input", inputDir.absolutePath))
+        assertThrows<MissingOption> {
+            NetexToolsCli().parse(listOf("filter", "--filter-config", filterConfig.absolutePath, "--input", inputDir.absolutePath))
         }
+    }
+
+    @Test
+    fun `filter command runs end-to-end with an optional --cli-config and creates the output directory`() {
+        // printReport=false avoids the report path; the empty input dir exercises the
+        // full parse -> select -> export flow and the --cli-config loading branch.
+        val cliConfig = File(tmpDir, "cli-config.json").apply {
+            writeText("""{ "logLevel": "WARN", "printReport": false }""")
+        }
+
+        NetexToolsCli().parse(
+            listOf(
+                "filter",
+                "--cli-config", cliConfig.absolutePath,
+                "--filter-config", filterConfig.absolutePath,
+                "--input", inputDir.absolutePath,
+                "--output", outputDir.absolutePath,
+            )
+        )
+
+        assertTrue(outputDir.isDirectory, "Expected the output directory to be created")
     }
 }


### PR DESCRIPTION
README updated with instructions on how to use the CLI

Note: this commit also deactivates publishing of the cli module on mvnrepository. The CLI is available as a thin JAR, meaning the developer will need to clone the repo, build the project and use the bin/netex-tools script provided in version control